### PR TITLE
[JENKINS-53935] Add SmokeTest Category for JUnit Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 *.iml
 *.ipr
 *.iws
+.idea

--- a/src/main/java/org/jvnet/hudson/test/SmokeTest.java
+++ b/src/main/java/org/jvnet/hudson/test/SmokeTest.java
@@ -1,7 +1,15 @@
 package org.jvnet.hudson.test;
 
 /**
- * Interface used as a Category for JUnit tests
+ * Interface used as a Category for classifying a test as a smoke-test.
+ *
+ * <p>
+ * All tests annotated like {@code @Category(SmokeTest.class)} would be run in the {@code smoke-test} suite.
+ * The {@code smoke-test} suite is meant for running unit tests and a number of functional tests.
+ * </p>
+ *
+ * @see <a href="https://github.com/junit-team/junit4/wiki/categories">https://github.com/junit-team/junit4/wiki/categories</a>
+ * @since TODO
  */
 public interface SmokeTest {
 }

--- a/src/main/java/org/jvnet/hudson/test/SmokeTest.java
+++ b/src/main/java/org/jvnet/hudson/test/SmokeTest.java
@@ -1,0 +1,7 @@
+package org.jvnet.hudson.test;
+
+/**
+ * Interface used as a Category for JUnit tests
+ */
+public interface SmokeTest {
+}


### PR DESCRIPTION
Add SmokeTest Interface as a JUnit test Category.
See https://github.com/jenkinsci/jenkins/pull/3855