### PR TITLE
Update parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.49</version>
+    <version>1.52</version>
   </parent>
   <artifactId>test-annotations</artifactId>
   


### PR DESCRIPTION
The main motivation is to enable SpotBugs for this repository. There were no existing violations, so doing so is as easy as bumping the parent POM. See [here](https://github.com/jenkinsci/pom/compare/jenkins-1.49...jenkins-1.52) for the full list of changes.