### PR TITLE
Adopt POM Code Convention

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -7,11 +8,18 @@
     <relativePath />
   </parent>
   <artifactId>test-annotations</artifactId>
-  
+
   <version>${revision}${changelist}</version>
   <name>Test annotations</name>
   <description>Annotations to associate test cases with other things</description>
   <url>https://github.com/jenkinsci/lib-${project.artifactId}</url>
+
+  <scm>
+    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
+  </scm>
 
   <properties>
     <revision>1.5</revision>
@@ -27,13 +35,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
-    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
-    <tag>${scmTag}</tag>
-  </scm>
 
   <repositories>
     <repository>


### PR DESCRIPTION
Adopts the [POM Code Convention](https://maven.apache.org/developers/conventions/code.html#pom-code-convention) that was [voted on by Maven developers in 2008](https://lists.apache.org/thread/h8px5t6f3q59cnkzpj1t02wsoynr3ygk). Note that this PR adds no automation; this is just a one-time pass.